### PR TITLE
Point package main at dist, not src. Fixes #8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-design-icons-iconfont",
   "version": "4.0.3",
   "description": "Material Design icons DX",
-  "main": "src/material-design-icons.scss",
+  "main": "dist/material-design-icons.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/jossef/material-design-icons-iconfont"


### PR DESCRIPTION
Allows user to write `import "material-design-icons-iconfont" in Webpack and relative path references work correctly.