### PR TITLE
Renamed unicode char DBFF for 'goat' to EBFF

### DIFF
--- a/dist/fonts/MaterialIcons-Regular.json
+++ b/dist/fonts/MaterialIcons-Regular.json
@@ -544,7 +544,7 @@
     "games": "E021",
     "grain": "E3EA",
     "group": "E7EF",
-    "goat": "DBFF",
+    "goat": "EBFF",
     "gif": "E908",
     "horizontal_split": "E947",
     "highlight_remove": "E888",

--- a/dist/material-design-icons.css
+++ b/dist/material-design-icons.css
@@ -1094,7 +1094,7 @@
   .material-icons.gif:before {
     content: "\e908"; }
   .material-icons.goat:before {
-    content: "\dbff"; }
+    content: "\ebff"; }
   .material-icons.golf_course:before {
     content: "\eb45"; }
   .material-icons.gps_fixed:before {

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -532,7 +532,7 @@ $material-icons-codepoints: map-merge((
 	"gesture": e155,
 	"get_app": e884,
 	"gif": e908,
-	"goat": dbff,
+	"goat": ebff,
 	"golf_course": eb45,
 	"gps_fixed": e1b3,
 	"gps_not_fixed": e1b4,


### PR DESCRIPTION
Unicode "DBFF" is a High Private Use Surrogate, which does not translate to a valid character. This potentially gives validation errors in various UTF validations and conversions, and I see no need for specifying characters in this range (correct me if I'm wrong).

Refs:
- https://unicode.org/faq/utf_bom.html#utf16-2
- https://www.compart.com/en/unicode/U+DBFF

The error was spotted when importing a transpiled angular css bundle into ASP.NET's StyleBundle loader, which in turn calls the C# method `System.Char.ConvertFromUtf32()` with value "0xdbff". This fails with the following error (for search reference):

> A valid UTF32 value is between 0x000000 and 0x10ffff, inclusive, and should not include surrogate codepoint values (0x00d800 ~ 0x00dfff)

_NOTE: If there are any automatic scrapers to download font definitions, these might need updates as well._